### PR TITLE
fixes bug with arc class

### DIFF
--- a/vedo/shapes.py
+++ b/vedo/shapes.py
@@ -1848,7 +1848,7 @@ class Arc(Mesh):
     ):
         if len(point1) == 2:
             point1 = (point1[0], point1[1], 0)
-        if point2 is not None and len(point2):
+        if point2 is not None and len(point2) == 2:
             point2 = (point2[0], point2[1], 0)
 
         ar = vtk.vtkArcSource()


### PR DESCRIPTION
Issue occurs when a point2 is set with a z value but is overwritten to zero in all cases. See below example

```python
import vedo
arc = vedo.shapes.Arc(
    center=[2, 2, 3], 
    point1=[2, 3, 3],
    point2=[3, 2, 3],  # <<< Z value of 3 is overwritten with 0.
    invert=False,
    c="f",
)
```