### PR TITLE
Add example to calculate and visualize sphere-fitted curvature

### DIFF
--- a/examples/advanced/measure_curvature.py
+++ b/examples/advanced/measure_curvature.py
@@ -1,6 +1,6 @@
-"""Calculate the surface curvature of an opject by fitting a sphere to 
-each vertex."""
-from vedo import *
+"""Calculate the surface curvature of an opject 
+by fitting a sphere to each vertex."""
+from vedo import printc, Ellipsoid, Plotter,fitSphere
 import numpy as np
 
 msh = Ellipsoid()
@@ -8,12 +8,12 @@ msh = Ellipsoid()
 printc(__doc__, invert=1)
 
 plt = Plotter(N=4, axes=1)
-plt.show(msh, at=0)
+plt.show(msh, "Original shape", at=0)
 
 # Use built-in curvature method
-msh1 = msh.clone().addCurvatureScalars(method=0).cmap('viridis').addScalarBar()
-msh1.name = 'Local curvature'
-msh1.show(at=1, azimuth=30, elevation=30).addLegendBox(width=0.3)
+msh1 = msh.clone().addCurvatureScalars(method=0).cmap('viridis')
+msh1.addScalarBar(horizontal=True, size=(100, None))
+plt.show(msh1, "Gaussian curvature", at=1, azimuth=30, elevation=30)
 
 # Use sphere-fit curvature
 msh2 = msh.clone()
@@ -25,24 +25,23 @@ residues = np.zeros(msh2.N())
 
 # iterate over surface points and fit sphere
 for idx in range(msh2.N()):
-    
-    patch = Points(msh2.closestPoint(msh2.points()[idx], radius=radius))
-    
+
+    patch = msh2.closestPoint(msh2.points()[idx], radius=radius)
     s = fitSphere(patch)
     curvature[idx] = 1/(s.radius)**2
     residues[idx] = s.residue
-    
-msh2.pointdata['Spherefit_Curvature'] = curvature
-msh2.pointdata['Spherefit_Curvature_residue'] = residues
 
-msh2.name = 'Sphere-fitted curvature'
-msh2.cmap('viridis', msh2.pointdata['Spherefit_Curvature']).addScalarBar()
-msh2.show(at=2).addLegendBox(width=0.4)
+msh2.pointdata['Spherefit_Curvature'] = curvature
+msh2.pointdata['Spherefit_Curvature_Residue'] = residues
+msh2.cmap('viridis', msh2.pointdata['Spherefit_Curvature'])
+msh2.addScalarBar(horizontal=True, size=(100, None))
+plt.show(msh2, "Sphere-fitted curvature", at=2)
 
 # Show fit residues
 msh3 = msh2.clone()
-msh3.cmap('jet', msh2.pointdata['Spherefit_Curvature_residue']).addScalarBar()
-msh3.name = 'Fit residues'
-msh3.show(at=3).addLegendBox(width=0.25)
+msh3.cmap('jet', msh2.pointdata['Spherefit_Curvature_Residue'])
+msh3.addScalarBar(horizontal=True, size=(100, None))
+plt.show(msh3, 'Sphere-fitted curvature\nFit residues', at=3)
+plt.interactive().close()
     
     

--- a/examples/advanced/measure_curvature.py
+++ b/examples/advanced/measure_curvature.py
@@ -1,0 +1,46 @@
+"""Calculate the surface curvature of an opject by fitting a sphere to 
+each vertex."""
+from vedo import *
+import numpy as np
+
+msh = Ellipsoid()
+
+printc(__doc__, invert=1)
+
+plt = Plotter(N=4, axes=1)
+plt.show(msh, at=0)
+
+# Use built-in curvature method
+msh1 = msh.clone().addCurvatureScalars(method=0).cmap('viridis').addScalarBar(title='Local curvature', horizontal=True, size=(100, None))
+msh1.show(at=1, azimuth=30, elevation=30)
+
+# Use sphere-fit curvature
+msh2 = msh.clone()
+
+# Set parameters and allocate arrays
+radius = 1.5
+curvature = np.zeros(msh2.N())
+residues = np.zeros(msh2.N())
+
+# iterate over surface points and fit sphere
+for idx in range(msh2.N()):
+    
+    patch = Points(msh2.closestPoint(msh2.points()[idx], radius=radius))
+    
+    s = fitSphere(patch)
+    curvature[idx] = 1/(s.radius)**2
+    residues[idx] = s.residue
+    
+msh2.pointdata['Spherefit_Curvature'] = curvature
+msh2.pointdata['Spherefit_Curvature_residue'] = residues
+msh2.show(at=2)
+
+msh2.cmap('viridis', msh2.pointdata['Spherefit_Curvature']).addScalarBar(title='Sphere-fitted curvature', horizontal=True, size=(100, None))
+msh2.show(at=2)
+
+# Show fit residues
+msh3 = msh2.clone()
+msh3.cmap('jet', msh2.pointdata['Spherefit_Curvature_residue']).addScalarBar(title='Fit residues', horizontal=True, size=(100, None))
+msh3.show(at=3)
+    
+    

--- a/examples/advanced/measure_curvature.py
+++ b/examples/advanced/measure_curvature.py
@@ -1,4 +1,4 @@
-"""Calculate the surface curvature of an opject 
+"""Calculate the surface curvature of an object 
 by fitting a sphere to each vertex."""
 from vedo import printc, Ellipsoid, Plotter,fitSphere
 import numpy as np

--- a/examples/advanced/measure_curvature.py
+++ b/examples/advanced/measure_curvature.py
@@ -11,8 +11,9 @@ plt = Plotter(N=4, axes=1)
 plt.show(msh, at=0)
 
 # Use built-in curvature method
-msh1 = msh.clone().addCurvatureScalars(method=0).cmap('viridis').addScalarBar(title='Local curvature', horizontal=True, size=(100, None))
-msh1.show(at=1, azimuth=30, elevation=30)
+msh1 = msh.clone().addCurvatureScalars(method=0).cmap('viridis').addScalarBar()
+msh1.name = 'Local curvature'
+msh1.show(at=1, azimuth=30, elevation=30).addLegendBox(width=0.3)
 
 # Use sphere-fit curvature
 msh2 = msh.clone()
@@ -33,14 +34,15 @@ for idx in range(msh2.N()):
     
 msh2.pointdata['Spherefit_Curvature'] = curvature
 msh2.pointdata['Spherefit_Curvature_residue'] = residues
-msh2.show(at=2)
 
-msh2.cmap('viridis', msh2.pointdata['Spherefit_Curvature']).addScalarBar(title='Sphere-fitted curvature', horizontal=True, size=(100, None))
-msh2.show(at=2)
+msh2.name = 'Sphere-fitted curvature'
+msh2.cmap('viridis', msh2.pointdata['Spherefit_Curvature']).addScalarBar()
+msh2.show(at=2).addLegendBox(width=0.4)
 
 # Show fit residues
 msh3 = msh2.clone()
-msh3.cmap('jet', msh2.pointdata['Spherefit_Curvature_residue']).addScalarBar(title='Fit residues', horizontal=True, size=(100, None))
-msh3.show(at=3)
+msh3.cmap('jet', msh2.pointdata['Spherefit_Curvature_residue']).addScalarBar()
+msh3.name = 'Fit residues'
+msh3.show(at=3).addLegendBox(width=0.25)
     
     


### PR DESCRIPTION
I added an example script that shows how to calculate surface curvatures based on the idea of fitting spheres to a local subset of points. The example demonstrates this on a basic shape (ellipsoid) and shows the built-in curvature (Method: Gaussian), the derived curvature from fitting a sphere as well as the residues of the fit process.

There is probably a smoother way to do the visualization, though.

Let me know what you think!

Fixes #610 