### PR TITLE
Increase the precision of camera info.

### DIFF
--- a/vedo/plotter.py
+++ b/vedo/plotter.py
@@ -3604,15 +3604,18 @@ class Plotter:
             return
 
         elif key == "C":
+            # Precision needs to be 7 (or even larger) to guarantee a consistent camera when 
+            #   the model coordinates are not centered at (0, 0, 0) and the mode is large. 
+            # This could happen for plotting geological models with UTM coordinate systems
             cam = self.renderer.GetActiveCamera()
             vedo.printc('\n###################################################', c='y')
             vedo.printc('## Template python code to position this camera: ##', c='y')
             vedo.printc('cam = dict(', c='y')
-            vedo.printc('    pos='          +utils.precision(cam.GetPosition(),4)+',', c='y')
-            vedo.printc('    focalPoint='   +utils.precision(cam.GetFocalPoint(),4)+',', c='y')
-            vedo.printc('    viewup='       +utils.precision(cam.GetViewUp(),4)+',', c='y')
-            vedo.printc('    distance='     +utils.precision(cam.GetDistance(),4)+',', c='y')
-            vedo.printc('    clippingRange='+utils.precision(cam.GetClippingRange(),4)+',', c='y')
+            vedo.printc('    pos='          +utils.precision(cam.GetPosition(),7)+',', c='y')
+            vedo.printc('    focalPoint='   +utils.precision(cam.GetFocalPoint(),7)+',', c='y')
+            vedo.printc('    viewup='       +utils.precision(cam.GetViewUp(),7)+',', c='y')
+            vedo.printc('    distance='     +utils.precision(cam.GetDistance(),7)+',', c='y')
+            vedo.printc('    clippingRange='+utils.precision(cam.GetClippingRange(),7)+',', c='y')
             vedo.printc(')', c='y')
             vedo.printc('show(mymeshes, camera=cam)', c='y')
             vedo.printc('###################################################', c='y')


### PR DESCRIPTION
Precision needs to be 7 (or even larger) to guarantee a consistent camera when the model coordinates are not centered at (0, 0, 0) and the mode is large. This could happen for plotting geological models with UTM coordinate systems. The default number 4 causes the camera settings to be wildly different each time you reload the model using the camera setting printed out by pressing 'C'.