### PR TITLE
add VTK_HEXAHEDRON to vedo.vtkcalsses

### DIFF
--- a/vedo/vtkclasses.py
+++ b/vedo/vtkclasses.py
@@ -46,6 +46,7 @@ from vtkmodules.vtkCommonCore import (
 )
 
 from vtkmodules.vtkCommonDataModel import (
+    VTK_HEXAHEDRON,
     VTK_TETRA,
     VTK_VOXEL,
     VTK_WEDGE,


### PR DESCRIPTION
Hi! This PR adds missing `VTK_HEXAHEDRON` import to fix the following error: 
```
vedo/vedo/ugrid.py", line 74, in __init__
    if ct == vtk.VTK_HEXAHEDRON:
AttributeError: module 'vedo.vtkclasses' has no attribute 'VTK_HEXAHEDRON'
```