### PR TITLE
Keep scalarbar(s) in Assembly

### DIFF
--- a/vedo/assembly.py
+++ b/vedo/assembly.py
@@ -225,7 +225,7 @@ class Assembly(vtk.vtkAssembly, vedo.base.Base3DProp):
             self.top = None
 
         for a in meshs:
-            if a:  # and a.GetNumberOfPoints():
+            if isinstance(a, vtk.vtkProp3D):  # and a.GetNumberOfPoints():
                 self.AddPart(a)
 
     def __add__(self, obj):

--- a/vedo/assembly.py
+++ b/vedo/assembly.py
@@ -88,7 +88,7 @@ class Group(vtk.vtkPropAssembly):
         self.transform = None
         self.scalarbar = None
 
-        for a in objects:
+        for a in vedo.utils.flatten(objects):
             if a:
                 self.AddPart(a)
             
@@ -248,10 +248,17 @@ class Assembly(vtk.vtkAssembly, vedo.base.Base3DProp):
         if hasattr(obj, "scalarbar") and obj.scalarbar is not None:
             if self.scalarbar is None:
                 self.scalarbar = obj.scalarbar
-            elif isinstance(self.scalarbar, Group):
-                self.scalarbar += obj.scalarbar
-            else:
-                self.scalarbar = Group(self.scalarbar, obj.scalarbar)
+                return self
+
+            def unpack_group(scalarbar):
+                if isinstance(scalarbar, Group):
+                    return scalarbar.unpack()
+                else:
+                    return scalarbar
+
+            self.scalarbar = Group(
+                [unpack_group(self.scalarbar), unpack_group(obj.scalarbar)]
+            )
 
         return self
 

--- a/vedo/assembly.py
+++ b/vedo/assembly.py
@@ -256,9 +256,12 @@ class Assembly(vtk.vtkAssembly, vedo.base.Base3DProp):
                 else:
                     return scalarbar
 
-            self.scalarbar = Group(
-                [unpack_group(self.scalarbar), unpack_group(obj.scalarbar)]
-            )
+            if isinstance(self.scalarbar, Group):
+                self.scalarbar += unpack_group(obj.scalarbar)
+            else:
+                self.scalarbar = Group(
+                    [unpack_group(self.scalarbar), unpack_group(obj.scalarbar)]
+                )
 
         return self
 

--- a/vedo/assembly.py
+++ b/vedo/assembly.py
@@ -224,16 +224,35 @@ class Assembly(vtk.vtkAssembly, vedo.base.Base3DProp):
             self.base = None
             self.top = None
 
+        scalarbars = []
         for a in meshs:
             if isinstance(a, vtk.vtkProp3D):  # and a.GetNumberOfPoints():
                 self.AddPart(a)
+            if hasattr(a, "scalarbar") and a.scalarbar is not None:
+                scalarbars.append(a.scalarbar)
+
+        if len(scalarbars) > 1:
+            self.scalarbar = Group(scalarbars)
+        elif len(scalarbars) == 1:
+            self.scalarbar = scalarbars[0]
 
     def __add__(self, obj):
         """
         Add an object to the assembly
         """
-        self.AddPart(obj)
+        if isinstance(obj, vtk.vtkProp3D):
+            self.AddPart(obj)
+
         self.actors.append(obj)
+
+        if hasattr(obj, "scalarbar") and obj.scalarbar is not None:
+            if self.scalarbar is None:
+                self.scalarbar = obj.scalarbar
+            elif isinstance(self.scalarbar, Group):
+                self.scalarbar += obj.scalarbar
+            else:
+                self.scalarbar = Group(self.scalarbar, obj.scalarbar)
+
         return self
 
     def __contains__(self, obj):

--- a/vedo/base.py
+++ b/vedo/base.py
@@ -1407,7 +1407,7 @@ class BaseActor(Base3DProp):
             if isinstance(self.scalarbar, vtk.vtkActor):
                 plt.renderer.RemoveActor(self.scalarbar)
             elif isinstance(self.scalarbar, vedo.Assembly):
-                for a in self.scalarbar.get_meshes():
+                for a in self.scalarbar.unpack():
                     plt.renderer.RemoveActor(a)
         if c is None:
             c = "gray"

--- a/vedo/pointcloud.py
+++ b/vedo/pointcloud.py
@@ -858,15 +858,15 @@ class Points(vtk.vtkFollower, BaseActor):
         if isinstance(meshs, list):
             alist = [self]
             for l in meshs:
-                if isinstance(l, vtk.vtkAssembly):
-                    alist += l.getMeshes()
+                if isinstance(l, vedo.Assembly):
+                    alist += l.unpack()
                 else:
                     alist += l
             return vedo.assembly.Assembly(alist)
 
-        if isinstance(meshs, vtk.vtkAssembly):
-            meshs.AddPart(self)
-            return meshs
+        if isinstance(meshs, vedo.Assembly):
+            return meshs + self  # use Assembly.__add__
+
         return vedo.assembly.Assembly([self, meshs])
 
     def polydata(self, transformed=True):

--- a/vedo/vtkclasses.py
+++ b/vedo/vtkclasses.py
@@ -498,6 +498,7 @@ from vtkmodules.vtkRenderingCore import (
     vtkPolyDataMapper,
     vtkPolyDataMapper2D,
     vtkProp,
+    vtkProp3D,
     vtkPropAssembly,
     vtkPropCollection,
     vtkPropPicker,


### PR DESCRIPTION
Hi @marcomusy!
I noticed that grouping meshes with `vedo.Assembly` loses track of scalarbar(s). If that's a desired behavior, feel free to close this PR :) 

This PR includes:
- keep scalarbar(s) alive in `Assembly` by grouping them with `Group`.
- minimal type check for `Assembly.AddPart()`
- update `Assembly.__add__` and `Points.__add__`
- replace `get_meshes()` with `unpack()`, if applicable


Here's a minimal reproducible example / test case:
```python
import vedo
import numpy as np


def offset(mesh, value, axis=False):
    """clone, pointdata, cmap, apply offset, scalarbar, add axis"""
    m = mesh.clone()
    m.pointdata["random"]  = np.random.random(len(m.points()))
    m.cmap(np.random.choice(vedo.colors.cmaps_names), "random")
    m.points(m.points() + value)
    m.add_scalarbar3d()
    if axis:
        m += vedo.Axes(m)
    return m


if __name__ == "__main__":

    # define shapes
    sphere1 = vedo.Sphere(pos=(-1,1,0), r=.5)
    sphere2 = vedo.Sphere(pos=(1,1,0), r=.5)
    arc = vedo.Arc(center=None, point1=[2,0,0], angle=-180, normal=[0,0,1])
    arc.lw(5)

    # assign pointdata, cmap, scalarbar
    sphere1.pointdata["arange"] = np.arange(len(sphere1.points()))
    sphere1.cmap("tab20", "arange")
    sphere1.add_scalarbar3d()

    sphere2.pointdata["linspace"] = np.linspace(-1,5,(len(sphere2.points())))
    sphere2.cmap("magma", "linspace")
    sphere2.add_scalarbar3d()

    arc.pointdata["random"] = np.random.random(len(arc.points()))
    arc.cmap("winter", "random")
    arc.add_scalarbar(title="arc")

    # Cases
    # 1. Assembly
    vedo.show("1. Assembly", vedo.Assembly(sphere1, sphere2, arc)).close()
    # 2. Assembly + Mesh (= (Mesh + Mesh) + Mesh)
    vedo.show("2. Assembly + Mesh", (sphere1 + sphere2) + arc).close()
    # 3. Mesh + Assembly (= Mesh + (Mesh + Mesh))
    vedo.show("3. Mesh + Assembly", sphere1 + (sphere2 + arc)).close()
    # 4. Assembly + Assembly (= (Assembly + Mesh) + (Mesh + Mesh))
    vedo.show(
        "4. Assembly + Assembly",
        (vedo.Axes(sphere1) + sphere1) + (sphere2 + arc),
    ).close()

    # 5. a lot of meshes with scalarbar
    # pre-define offsets
    o1, o2, o3, o4, o5 = 5, [5, 0, 0], [0, 5, 0], [-5, 0, 0], -5
    vedo.show(
        "5.",
        sphere1
        + offset(sphere1, o1)
        + offset(sphere1, o2, True)
        + offset(sphere1, o3)
        + offset(sphere1, o4)
        + offset(sphere1, o5)
        + sphere2.add_scalarbar(title="sphere", pos=(.8, .5))
        + offset(sphere2, o1)
        + offset(sphere2, o2)
        + offset(sphere2, o3, True)
        + offset(sphere2, o4)
        + offset(sphere2, o5, True)
        + arc
        + offset(arc, o1, True)
        + offset(arc, o2)
        + offset(arc, o3)
        + offset(arc, o4)
        + offset(arc, o5)
    )
```