### PR TITLE
Update API Documentation for Changing Backend

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -101,7 +101,7 @@ alias ve='vedo --eog '        # to view single and multiple images
 ```
 
 ## Running in a Jupyter Notebook
-To use in jupyter notebooks use the syntax `vedo.Plotter(backend='...')` the supported backend for visualization are:
+To use in jupyter notebooks use the syntax `vedo.settings.default_backend='' ` the supported backend for visualization are:
 
 - `2d`, the default a static image is generated.
 - `vtk`, in this case a normal graphics rendering window will pop up.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -101,7 +101,7 @@ alias ve='vedo --eog '        # to view single and multiple images
 ```
 
 ## Running in a Jupyter Notebook
-To use in jupyter notebooks use the syntax `vedo.settings.default_backend='' ` the supported backend for visualization are:
+To use in jupyter notebooks use the syntax `vedo.settings.default_backend= '...' ` the supported backend for visualization are:
 
 - `2d`, the default a static image is generated.
 - `vtk`, in this case a normal graphics rendering window will pop up.


### PR DESCRIPTION
The current API documentation still recommends the obsolete ` vedo.Plotter(backend='...') ` method for changing the visualization backend. This fixes it to recommend `settings.default_backend='...' `