### PR TITLE
Bugfix AnimationPlayer

### DIFF
--- a/examples/simulations/aspring2_player.py
+++ b/examples/simulations/aspring2_player.py
@@ -40,5 +40,6 @@ def update_scene(i: int):
 
 plt = AnimationPlayer(update_scene, irange=[0,200], loop=True)
 plt += [floor, wall, block, spring, text, __doc__]
+plt.set_frame(0)
 plt.show()
 plt.close()


### PR DESCRIPTION
Unfortunately, the latest changes brought some bugs, here's a fix for the bugs I could find.

bugs:
- when pressing pause, and then play, duplicate calls to func with the same idx
- if dragging the slider only slightly, duplicate calls to func with the same idx
- is already at `max_value - 1` and pressing play, duplicate call to func with the same idx
- if loop=False, the button would not show as paused when the animation reached the end
- example aspring2_player would make a jump at the beginning, because no calls to update_scene happened until pressing play/forward button

additional changes:
- now also possible to step backwards from `min_value `to `max_value-1` if `loop=True`, so looping in both directions is now allowed

note:
I wish it was possible to have `self.set_frame(self.min_value)` as the last line in the constructor for AnimationPlayer, but with the current layout of the class, that would call `_func` before all the necessary actors were added.