### PR TITLE
Change 'pointSize' occurrences to 'point_size'

### DIFF
--- a/vedo/file_io.py
+++ b/vedo/file_io.py
@@ -794,7 +794,7 @@ def loadPCD(filename):
     if expN != N:
         vedo.logger.warning(f"Mismatch in PCD file {expN} != {len(pts)}")
     poly = utils.buildPolyData(pts)
-    return Points(poly).pointSize(4)
+    return Points(poly).point_size(4)
 
 
 def tonumpy(obj):

--- a/vedo/pointcloud.py
+++ b/vedo/pointcloud.py
@@ -145,7 +145,7 @@ def visible_points(mesh, area=(), tol=None, invert=False):
         svp.SelectInvisibleOn()
     svp.Update()
 
-    m = Points(svp.GetOutput()).pointSize(5)
+    m = Points(svp.GetOutput()).point_size(5)
     m.name = "VisiblePoints"
     return m
 


### PR DESCRIPTION
Hi @marcomusy,

As you deprecated then removed the `pointSize` method, an error appears at the last occurrences that I found in the code.
Simply renamed them to `point_size`. 