### PR TITLE
extend pickable() for Assembly

### DIFF
--- a/vedo/assembly.py
+++ b/vedo/assembly.py
@@ -402,3 +402,12 @@ class Assembly(vedo.base.Base3DProp, vtk.vtkAssembly):
 
         return list(_genflatten([self]))
 
+    def pickable(self, value=None):
+        """Set/get the pickability property of an assembly and its elements"""
+        # set property to each element
+        if value is not None:
+            for elem in self.recursive_unpack():
+                elem.SetPickable(value)
+
+        # set property for self using inherited pickable()
+        return super().pickable(value=value)


### PR DESCRIPTION
Hi @marcomusy!

`vedo.Assembly.pickable(<bool>)` sets the property for itself, but pickability of its actors seems to stay untouched. Here's an example:
```python
import vedo

if __name__ == "__main__":
    # create meshes
    sphere = vedo.Sphere()
    axes = vedo.Axes(sphere)

    # create assembly using the meshes above
    assembly = sphere + axes
    assert isinstance(assembly, vedo.Assembly)

    # (1) shouldn't be pickable
    assembly.pickable(False)
    vedo.show(assembly, mode="TrackballActor")
    assert not assembly.pickable()

    # (2) should be pickable
    assembly.pickable(True)
    vedo.show(assembly, mode="TrackballActor")
    assert assembly.pickable()
```
This won't raise any `AssertionError`, but the meshes were still pickable in `(1)`. This PR extends pickable() to apply the property to its elements.