### PR TITLE
Minor fix to base.py

### DIFF
--- a/vedo/base.py
+++ b/vedo/base.py
@@ -512,8 +512,9 @@ class Base3DProp:
             # rotate around its origin
             rot[a](angle)
         else:
-            if around == "itself":
-                around = self.GetPosition()
+            if not utils.is_sequence(around):
+                if around == "itself":
+                    around = self.GetPosition()
             # displacement needed to bring it back to the origin
             # and disregard origin
             disp = around - np.array(self.GetOrigin())
@@ -2216,6 +2217,13 @@ class BaseGrid(BaseActor):
                 self._update(cout)
                 self.pipeline = utils.OperationNode("cut_with_box", parents=[self], c="#9e2a2b")
                 return self
+            elif isinstance(self, vedo.TetMesh):
+                # This is just to make sure if the input is a TetMesh, the code 
+                #   will still work
+                self._update(cout)
+                self.pipeline = utils.OperationNode("cut_with_box", parents=[self], c="#9e2a2b")
+                return self
+
             ug.pipeline = utils.OperationNode("cut_with_box", parents=[self], c="#9e2a2b")
             return ug
 


### PR DESCRIPTION
This commit fixes two issues:

- When you specify `around` when calling function `_rotatexyz`, the new version of Python would throw an error because `around` is compared directly with a string.

- When you want to run `cut_with_box` function with a `TetMesh` object, the original code would not do anything other than return a `UGrid` object that is not cut with the box. I do not understand the previous fix so I only tried to make the case with a `TetMesh` object work without introducing extra changes.