### PR TITLE
specified docstring in `decimate`

### DIFF
--- a/vedo/mesh.py
+++ b/vedo/mesh.py
@@ -960,7 +960,8 @@ class Mesh(MeshVisual, Points):
         """
         Downsample the number of vertices in a mesh to `fraction`.
 
-        This filter preserves the `pointdata` of the input dataset.
+        This filter preserves the `pointdata` of the input dataset. In previous versions
+        of vedo, this decimation algorithm was referred to as quadric decimation.
 
         Arguments:
             fraction : (float)


### PR DESCRIPTION
Fixes #1003 

Hi @marcomusy ,

tiny addon to the docstring of the `decimate` function so that readers know what function from older implementations this refers to :)

Best, Johannes