### PR TITLE
Typo in fast simplification example docstring: "faces" -> "vertices"

### DIFF
--- a/examples/other/fast_simpl.py
+++ b/examples/other/fast_simpl.py
@@ -1,5 +1,5 @@
 """Use fast-simplification to decimate a mesh and transfer
-data defined on the original faces to the decimated ones."""
+data defined on the original vertices to the decimated ones."""
 # https://github.com/pyvista/fast-simplification
 # pip install fast-simplification
 # Credits: Louis Pujol, see #992


### PR DESCRIPTION
Hello,

This PR follows the discussion in https://github.com/marcomusy/vedo/issues/992

The docstring of the fast-simplification example is updated as signal is transferred from vertices to vertices and not from faces to faces.