### PR TITLE
check actor's type in Assembly.__add__

### DIFF
--- a/vedo/assembly.py
+++ b/vedo/assembly.py
@@ -355,7 +355,7 @@ class Assembly(CommonVisual, Actor3DHelper, vtk.vtkAssembly):
         """
         Add an object to the assembly
         """
-        if isinstance(obj, vtk.get_class("Prop3D")):
+        if isinstance(getattr(obj, "actor", None), vtk.get_class("Prop3D")):
 
             self.objects.append(obj)
             self.actors.append(obj.actor)


### PR DESCRIPTION
Hi @marcomusy,

the type check in `vedo.Assembly.__add__` would return False most of the time. Which causes:
```python
a = vedo.Sphere()
b = vedo.Sphere()
c = vedo.Sphere()
d = a + b + c

assert isinstance(d, vedo.Assembly) # fine
assert len(d.actors) == 3 # error
assert len(d.actors) ==2 # fine
 
# try type check 
assert isinstance(vedo.Mesh(), vedo.vtkclasses.get_class("Prop3D")) # error
assert isinstance(vedo.Points(), vedo.vtkclasses.get_class("Prop3D")) # error
```
In this PR, it checks the type of `obj.actor` instead. 