### PR TITLE
backwards compatibility in typing with python < 3.11

### DIFF
--- a/vedo/addons.py
+++ b/vedo/addons.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import numpy as np
-from typing import Self, Union
+from typing import Union
+from typing_extensions import Self
 
 import vedo.vtkclasses as vtki   # a wrapper for lazy imports
 

--- a/vedo/core.py
+++ b/vedo/core.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import numpy as np
-from typing import Self, List, Union, Any
+from typing import List, Union, Any
+from typing_extensions import Self
 
 import vedo.vtkclasses as vtki
 

--- a/vedo/grids.py
+++ b/vedo/grids.py
@@ -3,7 +3,8 @@
 import os
 import time
 from weakref import ref as weak_ref_to
-from typing import Self, Any
+from typing import Any
+from typing_extensions import Self
 import numpy as np
 
 import vedo.vtkclasses as vtki  # a wrapper for lazy imports

--- a/vedo/image.py
+++ b/vedo/image.py
@@ -2,7 +2,8 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 from weakref import ref as weak_ref_to
-from typing import Self, Tuple, List, Union, Any
+from typing import Tuple, List, Union, Any
+from typing_extensions import Self
 
 import vedo.vtkclasses as vtki
 

--- a/vedo/mesh.py
+++ b/vedo/mesh.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import numpy as np
-from typing import List, Tuple, Union, MutableSequence, Any, Self
+from typing import List, Tuple, Union, MutableSequence, Any
+from typing_extensions import Self
 
 import vedo.vtkclasses as vtki  # a wrapper for lazy imports
 

--- a/vedo/plotter.py
+++ b/vedo/plotter.py
@@ -3,7 +3,8 @@
 import os.path
 import sys
 import time
-from typing import MutableSequence, Callable, Any, Union, Self
+from typing import MutableSequence, Callable, Any, Union
+from typing_extensions import Self
 import numpy as np
 
 import vedo.vtkclasses as vtki  # a wrapper for lazy imports

--- a/vedo/pointcloud.py
+++ b/vedo/pointcloud.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import time
-from typing import Self, Union, List
+from typing import Union, List
+from typing_extensions import Self
 from weakref import ref as weak_ref_to
 import numpy as np
 

--- a/vedo/pyplot.py
+++ b/vedo/pyplot.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-from typing import Self, Union
+from typing import Union
+from typing_extensions import Self
 import numpy as np
 
 import vedo.vtkclasses as vtki

--- a/vedo/transformations.py
+++ b/vedo/transformations.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-from typing import Self, List
+from typing import List
+from typing_extensions import Self
 import numpy as np
 
 import vedo.vtkclasses as vtki # a wrapper for lazy imports

--- a/vedo/visual.py
+++ b/vedo/visual.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import os
-from typing import Self, Union
+from typing import Union
+from typing_extensions import Self
 from weakref import ref as weak_ref_to
 import numpy as np
 

--- a/vedo/volume.py
+++ b/vedo/volume.py
@@ -2,7 +2,8 @@ import glob
 import os
 import time
 from weakref import ref as weak_ref_to
-from typing import Self, Union, List, Iterable
+from typing import Union, List, Iterable
+from typing_extensions import Self
 
 import numpy as np
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Standardized the import of `Self` type hint across various components to enhance code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->