### PR TITLE
avoid overwriting screenshots with `"S"` key

### DIFF
--- a/vedo/plotter.py
+++ b/vedo/plotter.py
@@ -4093,11 +4093,11 @@ class Plotter:
             return
 
         elif key == "S":
-            def serial_fname(start=0):
-                fname = f"screenshot{int(start) if start > 0 else ''}.png"
-                return serial_fname(start + 1) if os.path.isfile(fname) else fname
-
-            fname = serial_fname()
+            fname = "screenshot.png"
+            i = 1
+            while os.path.isfile(fname):
+                fname = f"screenshot{i}.png"
+                i += 1
             vedo.file_io.screenshot(fname)
             vedo.printc(rf":camera: Saved rendering window to {fname}", c="b")
             return

--- a/vedo/plotter.py
+++ b/vedo/plotter.py
@@ -4093,8 +4093,13 @@ class Plotter:
             return
 
         elif key == "S":
-            vedo.file_io.screenshot("screenshot.png")
-            vedo.printc(r":camera: Saved rendering window to 'screenshot.png'", c="b")
+            def serial_fname(start=0):
+                fname = f"screenshot{int(start) if start > 0 else ''}.png"
+                return serial_fname(start + 1) if os.path.isfile(fname) else fname
+
+            fname = serial_fname()
+            vedo.file_io.screenshot(fname)
+            vedo.printc(rf":camera: Saved rendering window to {fname}", c="b")
             return
 
         elif key == "C":


### PR DESCRIPTION
Hi Marco!
If I try to take several screenshots from one script using `"S"` key, I'd only get the last one saved. This PR tries to assign a unique file name by appending a natural number to the base name.
File names would look like this:
```
📸 Saved rendering window to screenshot.png
📸 Saved rendering window to screenshot1.png
📸 Saved rendering window to screenshot2.png
📸 Saved rendering window to screenshot3.png
📸 Saved rendering window to screenshot4.png
...
```
or
```bash
$ touch screenshot3.png
$ python a_script.py
📸 Saved rendering window to screenshot.png
📸 Saved rendering window to screenshot1.png
📸 Saved rendering window to screenshot2.png
📸 Saved rendering window to screenshot4.png
📸 Saved rendering window to screenshot5.png
...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced screenshot functionality to automatically generate unique filenames, preventing overwriting of existing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->