### PR TITLE
minor bug in RoundedLine

### DIFF
--- a/vedo/shapes.py
+++ b/vedo/shapes.py
@@ -968,7 +968,16 @@ class RoundedLine(Mesh):
                 if k == 0:
                     ptsnew.append(p0 + nv)
                 if uv[2] <= 0:
-                    alpha = np.arccos(np.dot(u, v) / du / dv)
+                    # the following computation can return a value
+                    # ever so slightly > 1.0 causing argcos to fail.
+                    uv_arg = np.dot(u, v) / du / dv
+                    if uv_arg > 1.0:
+                        # since the argument to arcos is 1, simply
+                        # assign alpha to 0.0 without calculating the
+                        # arccos
+                        alpha = 0.0
+                    else:
+                        alpha = np.arccos(uv_arg)
                     db = lw * np.tan(alpha / 2)
                     p1new = p1 + nv - v / dv * db
                     ptsnew.append(p1new)

--- a/vedo/shapes.py
+++ b/vedo/shapes.py
@@ -969,7 +969,7 @@ class RoundedLine(Mesh):
                     ptsnew.append(p0 + nv)
                 if uv[2] <= 0:
                     # the following computation can return a value
-                    # ever so slightly > 1.0 causing argcos to fail.
+                    # ever so slightly > 1.0 causing arccos to fail.
                     uv_arg = np.dot(u, v) / du / dv
                     if uv_arg > 1.0:
                         # since the argument to arcos is 1, simply


### PR DESCRIPTION
every once in a while the computation for argument of arccos can return a value slightly greater than 1
trap the occurence and simply return the angle of 0 (since the argument to arccos is supposed to be 1 anyway)