### PR TITLE
bugfix: add tolerance to contains

### DIFF
--- a/vedo/shapes.py
+++ b/vedo/shapes.py
@@ -3047,7 +3047,7 @@ class Plane(Mesh):
         points = np.array(points, dtype=float)
         bounds = self.vertices
 
-        mask = np.isclose(np.dot(points - self.center, self.normal), 0, rtol=tol)
+        mask = np.isclose(np.dot(points - self.center, self.normal), 0, atol=tol)
 
         for i in [1, 3]:
             AB = bounds[i] - bounds[0]

--- a/vedo/shapes.py
+++ b/vedo/shapes.py
@@ -3047,7 +3047,7 @@ class Plane(Mesh):
         points = np.array(points, dtype=float)
         bounds = self.vertices
 
-        mask = np.isclose(np.dot(points - self.center, self.normal), tol)
+        mask = np.isclose(np.dot(points - self.center, self.normal), 0, rtol=tol)
 
         for i in [1, 3]:
             AB = bounds[i] - bounds[0]


### PR DESCRIPTION
As per https://numpy.org/doc/stable/reference/generated/numpy.isclose.html, 
`numpy.isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False)`

Currently, b is set to tol, which defaults to 0. It should always be 0 and the tol should either be relative or absolute (rtol/atol). Therefore the setting of input variables is incorrect at the moment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced the accuracy of shape containment checks by adjusting the tolerance parameter in the `contains` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->