### PR TITLE
Mitigate issue #769: don't set backend to '2d' in IPython REPLs

### DIFF
--- a/vedo/settings.py
+++ b/vedo/settings.py
@@ -231,8 +231,10 @@ class Settings:
 
         self.default_backend = "vtk"
         try:
-            get_ipython()
-            self.default_backend = "2d"
+            # adapted from: https://stackoverflow.com/a/39662359/2912349
+            shell = get_ipython().__class__.__name__
+            if shell == 'ZMQInteractiveShell':
+                self.default_backend = "2d"
         except NameError:
             pass
 


### PR DESCRIPTION
This PR attempts to mitigate issue #769, that arises due to the Jupyter notebook detection resulting in a false positive when working in an IPython REPL. 