### PR TITLE
Print position parameter as 'pos'

### DIFF
--- a/vedo/plotter.py
+++ b/vedo/plotter.py
@@ -4125,7 +4125,7 @@ class Plotter:
             vedo.printc("\n###################################################", c="y")
             vedo.printc("## Template python code to position this camera: ##", c="y")
             vedo.printc("cam = dict(", c="y")
-            vedo.printc("    position=" + utils.precision(cam.GetPosition(), 6) + ",", c="y")
+            vedo.printc("    pos=" + utils.precision(cam.GetPosition(), 6) + ",", c="y")
             vedo.printc("    focal_point=" + utils.precision(cam.GetFocalPoint(), 6) + ",", c="y")
             vedo.printc("    viewup=" + utils.precision(cam.GetViewUp(), 6) + ",", c="y")
             vedo.printc("    roll=" + utils.precision(cam.GetRoll(), 6) + ",", c="y")


### PR DESCRIPTION
Hi @marcomusy. I noticed that when printing the camera position, it returns `position` when the docs state it should be `pos`.

This PR changes this from `position` to `pos` to match the docs and helps us stay consistent in brainrender.

I think this is a simple change, but let me know if I've missed anything. 

