### PR TITLE
Prevent merging close vertices when converting to Trimesh

### DIFF
--- a/vedo/utils.py
+++ b/vedo/utils.py
@@ -2471,7 +2471,7 @@ def vedo2trimesh(mesh):
     if len(tris) == 0:
         tris = None
 
-    return Trimesh(vertices=points, faces=tris, face_colors=ccols, vertex_colors=vcols)
+    return Trimesh(vertices=points, faces=tris, face_colors=ccols, vertex_colors=vcols, process=False)
 
 
 def trimesh2vedo(inputobj):


### PR DESCRIPTION
Calling vedo2trimesh() can result in the loss of vertices, as initializing a Trimesh mesh merges close vertices by default (with a tolerance of 1e-8). 

Adding `process=False` prevents this and ensures that the converted mesh does not get altered.