### PR TITLE
raise an error when calling cell_normals before compute_normals()

### DIFF
--- a/vedo/mesh.py
+++ b/vedo/mesh.py
@@ -281,7 +281,10 @@ class Mesh(MeshVisual, Points):
         Check out also `compute_normals(cells=True)` and `compute_normals_with_pca()`.
         """
         vtknormals = self.dataset.GetCellData().GetNormals()
-        return vtk2numpy(vtknormals)
+        numpy_normals = vtk2numpy(vtknormals)
+        if len(numpy_normals) == 0 and len(self.cells) != 0:
+            raise ValueError("VTK failed to return any normal vectors. You may need to call `Mesh.compute_normals()` before accessing `Mesh.cell_normals`.")
+        return numpy_normals
 
     def compute_normals(self, points=True, cells=True, feature_angle=None, consistency=True) -> Self:
         """


### PR DESCRIPTION
Right now if you call cell_normals before calling compute_normals(), it will simply return an empty array.  This is incorrect, and is especially confusing because if a user is new to vedo they will have no way of knowing that there's another function they need to call first, unless they happen to notice it in the API.

This PR has it raise an error instead, thus preventing it from returning the wrong answer while also letting the user know how to fix the problem.