### PR TITLE
Update file_io.py

### DIFF
--- a/vedo/file_io.py
+++ b/vedo/file_io.py
@@ -1774,6 +1774,7 @@ def load_obj(fileinput: Union[str, os.PathLike], mtl_file=None, texture_path=Non
         vactor = actors.GetNextActor()
         msh = Mesh(vactor)
         msh.name = "OBJMesh"
+        msh.copy_properties_from(vactor)
         tx = vactor.GetTexture()
         if tx:
             msh.texture(tx)


### PR DESCRIPTION
Bug fixes for `load_obj` (ref: #891, #1023). Support coping properties from `.obj` model loaded by VTK.