### PR TITLE
Add lazy initialization for normals (#1231)

### DIFF
--- a/vedo/mesh.py
+++ b/vedo/mesh.py
@@ -270,21 +270,31 @@ class Mesh(MeshVisual, Points):
                 break
         return conn  # cannot always make a numpy array of it!
 
+    @property 
+    def vertex_normals(self) -> np.ndarray:
+        """
+        Retrieve vertex normals as a numpy array. 
+        If need be normals are computed via `compute_normals()`.
+        Check out also `compute_normals()` and `compute_normals_with_pca()`.
+        """
+        vtknormals = self.dataset.GetPointData().GetNormals()
+        if vtknormals is None:
+            self.compute_normals()
+            vtknormals = self.dataset.GetPointData().GetNormals()
+        return vtk2numpy(vtknormals)
+
     @property
-    def cell_normals(self):
+    def cell_normals(self) -> np.ndarray:
         """
         Retrieve face normals as a numpy array.
+        If need be normals are computed via `compute_normals()`.
         Check out also `compute_normals(cells=True)` and `compute_normals_with_pca()`.
         """
         vtknormals = self.dataset.GetCellData().GetNormals()
-        numpy_normals = vtk2numpy(vtknormals)
-        if len(numpy_normals) == 0 and len(self.cells) != 0:
-            vedo.logger.warning(
-                "failed to return normal vectors.\n"
-                "You may need to call `Mesh.compute_normals()` before accessing 'Mesh.cell_normals'."
-            )
-            numpy_normals = np.zeros((self.ncells, 3)) + [0,0,1]
-        return numpy_normals
+        if vtknormals is None:
+            self.compute_normals()
+            vtknormals = self.dataset.GetCellData().GetNormals()
+        return vtk2numpy(vtknormals)
 
     def compute_normals(self, points=True, cells=True, feature_angle=None, consistency=True) -> Self:
         """

--- a/vedo/pointcloud.py
+++ b/vedo/pointcloud.py
@@ -1155,9 +1155,13 @@ class Points(PointsVisual, PointAlgorithms):
     def vertex_normals(self) -> np.ndarray:
         """
         Retrieve vertex normals as a numpy array. Same as `point_normals`.
+        If need be normals are computed via `compute_normals_with_pca()`.
         Check out also `compute_normals()` and `compute_normals_with_pca()`.
         """
         vtknormals = self.dataset.GetPointData().GetNormals()
+        if vtknormals is None:
+            self.compute_normals_with_pca()
+            vtknormals = self.dataset.GetPointData().GetNormals()
         return utils.vtk2numpy(vtknormals)
 
     @property
@@ -1166,8 +1170,7 @@ class Points(PointsVisual, PointAlgorithms):
         Retrieve vertex normals as a numpy array. Same as `vertex_normals`.
         Check out also `compute_normals()` and `compute_normals_with_pca()`.
         """
-        vtknormals = self.dataset.GetPointData().GetNormals()
-        return utils.vtk2numpy(vtknormals)
+        return self.vertex_normals
 
     def align_to(self, target, iters=100, rigid=False, invert=False, use_centroids=False) -> Self:
         """


### PR DESCRIPTION
Hi @marcomusy 

As discussed  (#1231), here's a PR for lazy initialisation of cell and vertex normals, making the API more straightforward. Normals can still be computed explicitly, if need be.

Note the lazy initialisation uses `compute_normals()` and `compute_normals_with_pca()` depending on whether it is a point cloud or a polygonal mesh.