### PR TITLE
Use specialized reader for OME-TIFF files.

### DIFF
--- a/vedo/file_io.py
+++ b/vedo/file_io.py
@@ -1214,7 +1214,11 @@ def _import_npy(fileinput: Union[str, os.PathLike]) -> "vedo.Plotter":
 def loadImageData(filename: Union[str, os.PathLike]) -> Union[vtki.vtkImageData, None]:
     """Read and return a `vtkImageData` object from file."""
     filename = str(filename)
-    if ".tif" in filename.lower():
+    if ".ome.tif" in filename.lower():
+        reader = vtki.new("OMETIFFReader")
+        # print("GetOrientationType ", reader.GetOrientationType())
+        reader.SetOrientationType(vedo.settings.tiff_orientation_type)
+    elif ".tif" in filename.lower():
         reader = vtki.new("TIFFReader")
         # print("GetOrientationType ", reader.GetOrientationType())
         reader.SetOrientationType(vedo.settings.tiff_orientation_type)

--- a/vedo/vtkclasses.py
+++ b/vedo/vtkclasses.py
@@ -454,6 +454,7 @@ for name in [
     "vtkNIFTIImageReader",
     "vtkNIFTIImageWriter",
     "vtkNrrdReader",
+    "vtkOMETIFFReader",
     "vtkPNGReader",
     "vtkPNGWriter",
     "vtkSLCReader",


### PR DESCRIPTION
- The ome.tif extension is specified at https://ome-model.readthedocs.io/en/stable/ome-tiff/specification.html
- The specialized reader is able to distinguish axes such as time / channel / depth in the tiff stack, which all get smushed together by the plain tiff reader.